### PR TITLE
Fix: Validate image dimensions and enhance fallback logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -6,6 +6,7 @@ function loadBackgroundImage() {
         console.error('Error: image-area element not found!');
         return;
     }
+    let initialAttemptWasWithDynamicDimensions = false;
 
     // imageArea.style.backgroundColor = '#ddd'; // Placeholder
     // imageArea.style.textAlign = 'center'; // From original
@@ -22,15 +23,27 @@ function loadBackgroundImage() {
         displayTeachableObjects();
     };
     img.onerror = () => {
-        console.error(`Error loading background image from Unsplash. Check network or Unsplash status. URL: ${img.src}`);
-        if (imageArea) {
-            // imageArea.style.backgroundImage = ''; // Keep it simple
-            // imageArea.style.backgroundColor = '#eee';
-            imageArea.innerHTML = '<p style="text-align:center; padding-top: 50px; color: #555;">Could not load image from Unsplash. Enjoy the words on a plain background!</p>';
+        if (initialAttemptWasWithDynamicDimensions) {
+            console.warn(`Initial attempt with dynamic dimensions (${width}x${height}) failed. Trying fallback 800x600. URL: ${img.src}`);
+            initialAttemptWasWithDynamicDimensions = false; // Prevent retry loop
+            img.src = 'https://picsum.photos/seed/picsum/800/600'; // Fallback
+        } else {
+            console.error(`Error loading background image from Unsplash. Also failed with fallback or fallback was initial. URL: ${img.src}`);
+            if (imageArea) {
+                imageArea.innerHTML = '<p style="text-align:center; padding-top: 50px; color: #555;">Could not load image from Unsplash. Enjoy the words on a plain background!</p>';
+            }
+            displayTeachableObjects(); // Still display words even if image fails
         }
-        displayTeachableObjects(); // Still display words even if image fails
     };
-    img.src = `https://picsum.photos/seed/picsum/${imageArea.offsetWidth}/${imageArea.offsetHeight}`;
+    const width = imageArea.offsetWidth;
+    const height = imageArea.offsetHeight;
+    if (width && height && !isNaN(width) && !isNaN(height) && width > 0 && height > 0) {
+        initialAttemptWasWithDynamicDimensions = true;
+        img.src = `https://picsum.photos/seed/picsum/${width}/${height}`;
+    } else {
+        initialAttemptWasWithDynamicDimensions = false; // Ensure it's false if we go directly to fallback
+        img.src = 'https://picsum.photos/seed/picsum/800/600'; // Fallback
+    }
 }
 
 let animationFrameId = null; // To control animation loop


### PR DESCRIPTION
The `loadBackgroundImage` function was modified to address issues with image loading from picsum.photos:

1.  Validates that `offsetWidth` and `offsetHeight` of the image area are positive numbers before using them in the image URL.
2.  If dimensions are invalid, a fallback URL with default dimensions (800x600) is used.
3.  The `onerror` handler for image loading has been enhanced:
    *   If an image load fails with dynamic dimensions, it now attempts a second load using the fallback URL (800x600).
    *   The user-facing error message is only displayed if both attempts (dynamic and/or fallback) fail.

This makes the image loading more resilient to invalid dimension values and potential transient issues with specific image sizes.